### PR TITLE
Adding exportto.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1320,6 +1320,17 @@ docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
 tests = ["hypothesis (>=3.27.0)", "pytest (>=3.2.1,!=3.3.0)"]
 
 [[package]]
+name = "pypandoc"
+version = "1.11"
+description = "Thin wrapper for pandoc."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "pypandoc-1.11-py3-none-any.whl", hash = "sha256:b260596934e9cfc6513056110a7c8600171d414f90558bf4407e68b209be8007"},
+    {file = "pypandoc-1.11.tar.gz", hash = "sha256:7f6d68db0e57e0f6961bec2190897118c4d305fc2d31c22cd16037f22ee084a5"},
+]
+
+[[package]]
 name = "pyrsistent"
 version = "0.19.3"
 description = "Persistent/Functional/Immutable data structures"
@@ -1749,4 +1760,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "017d8c1ed504394abdb3e26381a3400c8ec23423705f3466d904b1d04986e7e3"
+content-hash = "6d1a6a8fb612318caad819974e650238c5447960752bef06a153d2b9d7a8d09f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ blinker = "^1.6.2"
 slugify = "^0.0.1"
 complianceio = {git = "https://github.com/CivicActions/compliance-io.git"}
 pytest = "^7.4.0"
+pypandoc = "^1.11"
 
 [build-system]
 requires = ["poetry-core"]
@@ -29,4 +30,5 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry.scripts]
 createfiles = "tools.createfiles.createfiles:main"
 creatematrix = "tools.creatematrix.creatematrix:main"
+exportto = "tools.exportto.exportto:main"
 makefamilies = "tools.makefamilies.makefamilies:main"

--- a/tools/createfiles/createfiles.py
+++ b/tools/createfiles/createfiles.py
@@ -1,6 +1,6 @@
 """
-Copyright 2019-2020 CivicActions, Inc. See the README file at the top-level
-directory of this distribution and at https://github.com/CivicActions/compliancetools#copyright.
+Copyright 2019-2023 CivicActions, Inc. See the README file at the top-level
+directory of this distribution and at https://github.com/CivicActions/ssp-toolkit#copyright.
 
 
 Given a YAML file and path to directory of template files, this tool

--- a/tools/creatematrix/creatematrix.py
+++ b/tools/creatematrix/creatematrix.py
@@ -1,6 +1,6 @@
 """
-Copyright 2019-2020 CivicActions, Inc. See the README file at the top-level
-directory of this distribution and at https://github.com/CivicActions/compliancetools#copyright.
+Copyright 2019-2023 CivicActions, Inc. See the README file at the top-level
+directory of this distribution and at https://github.com/CivicActions/ssp-toolkit#copyright.
 """
 
 import csv

--- a/tools/exportto/exportto.py
+++ b/tools/exportto/exportto.py
@@ -1,0 +1,74 @@
+"""
+Copyright 2019-2023 CivicActions, Inc. See the README file at the top-level
+directory of this distribution and at https://github.com/CivicActions/ssp-toolkit#copyright.
+"""
+
+from pathlib import Path
+
+import click
+from pypandoc import convert_file
+
+
+def render_multiple(to_render: Path, file_type: str, output_to: Path):
+    for file_path in to_render.glob("**/*.md"):
+        render_file(to_render=file_path, file_type=file_type, output_to=output_to)
+
+
+def render_file(to_render: Path, file_type: str, output_to: Path):
+    args: list = []
+    filepath = output_to.joinpath(to_render.stem).with_suffix(f".{file_type}")
+    if file_type == "docx" and Path("assets/custom-reference.docx").exists():
+        args.append("--reference-doc=assets/custom-reference.docx")
+
+    convert_file(
+        source_file=to_render,
+        to=file_type,
+        outputfile=str(filepath),
+        extra_args=args,
+    )
+    print(f"Writing file {filepath.as_posix()}")
+
+
+@click.command()
+@click.option(
+    "--render_file",
+    "-r",
+    "render",
+    type=click.Path(exists=True, dir_okay=True, file_okay=True, readable=True),
+    help="The directory containing the files, or a file, to render.",
+)
+@click.option(
+    "--type",
+    "-t",
+    "file_type",
+    required=False,
+    default="docx",
+    help="The file type to create using Pandoc (default: docx)",
+)
+@click.option(
+    "--out",
+    "-o",
+    "output",
+    type=click.Path(exists=False, dir_okay=True, readable=True),
+    default="docx",
+    help="Output directory (default: docx)",
+)
+def main(render: str, file_type: str, output: str):
+    output_to = Path(output)
+    if not output_to.exists():
+        output_to.mkdir(exist_ok=False)
+
+    to_render = Path(render)
+    if to_render.exists():
+        if to_render.is_dir():
+            render_multiple(
+                to_render=to_render, file_type=file_type, output_to=output_to
+            )
+        else:
+            render_file(to_render=to_render, file_type=file_type, output_to=output_to)
+    else:
+        raise FileNotFoundError
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/helpers/secrender.py
+++ b/tools/helpers/secrender.py
@@ -1,6 +1,6 @@
 """
-Copyright 2019-2020 CivicActions, Inc. See the README file at the top-level
-directory of this distribution and at https://github.com/CivicActions/compliancetools#copyright.
+Copyright 2019-2023 CivicActions, Inc. See the README file at the top-level
+directory of this distribution and at https://github.com/CivicActions/ssp-toolkit#copyright.
 
 
 Example tool to render a template using data loaded from a YAML

--- a/tools/helpers/ssptoolkit.py
+++ b/tools/helpers/ssptoolkit.py
@@ -1,6 +1,6 @@
 """
-Copyright 2019-2020 CivicActions, Inc. See the README file at the top-level
-directory of this distribution and at https://github.com/CivicActions/compliancetools#copyright.
+Copyright 2019-2023 CivicActions, Inc. See the README file at the top-level
+directory of this distribution and at https://github.com/CivicActions/ssp-toolkit#copyright.
 """
 
 import re

--- a/tools/makefamilies/family.py
+++ b/tools/makefamilies/family.py
@@ -1,6 +1,6 @@
 """
-Copyright 2019-2020 CivicActions, Inc. See the README file at the top-level
-directory of this distribution and at https://github.com/CivicActions/compliancetools#copyright.
+Copyright 2019-2023 CivicActions, Inc. See the README file at the top-level
+directory of this distribution and at https://github.com/CivicActions/ssp-toolkit#copyright.
 """
 
 from collections import OrderedDict

--- a/tools/makefamilies/makefamilies.py
+++ b/tools/makefamilies/makefamilies.py
@@ -1,6 +1,6 @@
 """
-Copyright 2019-2020 CivicActions, Inc. See the README file at the top-level
-directory of this distribution and at https://github.com/CivicActions/compliancetools#copyright.
+Copyright 2019-2023 CivicActions, Inc. See the README file at the top-level
+directory of this distribution and at https://github.com/CivicActions/ssp-toolkit#copyright.
 """
 
 from pathlib import Path


### PR DESCRIPTION
Adding `exportto`
```shell
Usage: exportto [OPTIONS]

Options:
  -r, --render_file PATH  The directory containing the files, or a file, to
                          render.
  -t, --type TEXT         The file type to create using Pandoc (default: docx)
  -o, --out PATH          Output directory (default: docx)
  --help                  Show this message and exit.
```